### PR TITLE
Add RememberWidths capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 This repo is a drop-in replacement for the golang [text/tabwriter](https://golang.org/pkg/text/tabwriter/) package.
 
 It is based on that package at [cf2c2ea8](https://github.com/golang/go/tree/cf2c2ea89d09d486bb018b1817c5874388038c3a/src/text/tabwriter) and inherits its license.
+
+The following additional features are supported:
+* `RememberWidths` flag allows remembering maximum widths seen per column even after Flush() is called.
+* `RememberedWidths() []int` and `SetRememberedWidths([]int) *Writer` allows obtaining and transferring remembered column width between writers.

--- a/example_test.go
+++ b/example_test.go
@@ -72,3 +72,27 @@ func Example_trailingTab() {
 	// ----aaa|----bbb|unaligned
 	// ---aaaa|---bbbb|---aligned|
 }
+
+func Example_rememberWidth() {
+	// Observe that the columns continue to line up after the Flush() call,
+	// as long as they are no wider than previously written columns
+	const padding = 3
+	w := tabwriter.NewWriter(os.Stdout, 4, 6, 3, ' ', tabwriter.RememberWidths|tabwriter.Debug)
+	fmt.Fprintln(w, "a\tb\tc")
+	fmt.Fprintln(w, "ddd\teeeee\tfff")
+	w.Flush()
+	fmt.Fprintln(w, "g\thh\tii")
+	fmt.Fprintln(w, "jjj\tk\tl")
+	w.Flush()
+	fmt.Fprintln(w, "mmmmm\tn\to")
+	fmt.Fprintln(w, "p\tqqq\trrr")
+	w.Flush()
+
+	// output:
+	// a     |b       |c
+	// ddd   |eeeee   |fff
+	// g     |hh      |ii
+	// jjj   |k       |l
+	// mmmmm   |n       |o
+	// p       |qqq     |rrr
+}


### PR DESCRIPTION
Adds the `RememberWidths` flag

This enables calling Flush(), then continuing to call Write() and have subsequent lines match previously written/flushed lines as much as possible. Columns will grow as needed.

Remembered widths can be obtained using `RememberedWidths() []int`

Remembered widths can be set using `SetRememberedWidths([]int) *Writer`, which allows transferring state to a new tab writer