### PR TITLE
New flag to smash escaped text to zero width

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ It is based on that package at [cf2c2ea8](https://github.com/golang/go/tree/cf2c
 The following additional features are supported:
 * `RememberWidths` flag allows remembering maximum widths seen per column even after Flush() is called.
 * `RememberedWidths() []int` and `SetRememberedWidths([]int) *Writer` allows obtaining and transferring remembered column width between writers.
+* `SmashEscape` flag ignores escaped text when determining the column width. This is useful for coloring text in columns.

--- a/tabwriter.go
+++ b/tabwriter.go
@@ -199,6 +199,10 @@ const (
 
 	// Remember maximum widths seen per column even after Flush() is called.
 	RememberWidths
+
+	// Smash escaped text to zero width, but output the whole text unescaped.
+	// This is useful to colorize output in terminals.
+	SmashEscape
 )
 
 // A Writer must be initialized with a call to Init. The first parameter (output)
@@ -472,9 +476,13 @@ func (b *Writer) startEscape(ch byte) {
 func (b *Writer) endEscape() {
 	switch b.endChar {
 	case Escape:
-		b.updateWidth()
-		if b.flags&StripEscape == 0 {
-			b.cell.width -= 2 // don't count the Escape chars
+		if b.flags&SmashEscape == 0 {
+			b.updateWidth()
+			if b.flags&StripEscape == 0 {
+				b.cell.width -= 2 // don't count the Escape chars
+			}
+		} else {
+			b.pos = len(b.buf)
 		}
 	case '>': // tag of zero width
 	case ';':

--- a/tabwriter_test.go
+++ b/tabwriter_test.go
@@ -612,6 +612,34 @@ var tests = []struct {
 			"a\t|b\t|c\t|d\n" +
 			"a\t|b\t|c\t|d\t|e\n",
 	},
+
+	{
+		"smashed escape test",
+		8, 4, 0, '.', StripEscape | SmashEscape,
+		"\xffsmashed_\xffcell1\tcell2",
+		"smashed_cell1...cell2",
+	},
+
+	{
+		"smashed escape test with padding",
+		8, 4, 2, '.', StripEscape | SmashEscape,
+		"\xffsmashed_\xffcell1\tcell2\nlong cell3\tcell4",
+		"smashed_cell1.......cell2\nlong cell3..cell4",
+	},
+
+	{
+		"smashed escape test, no-strip",
+		8, 4, 0, '.', SmashEscape,
+		"\xffsmashed_\xffcell1\tcell2",
+		"\xffsmashed_\xffcell1...cell2",
+	},
+
+	{
+		"smashed escape test with padding, no-strip",
+		8, 4, 2, '.', SmashEscape,
+		"\xffsmashed_\xffcell1\tcell2\nlong cell3\tcell4",
+		"\xffsmashed_\xffcell1.......cell2\nlong cell3..cell4",
+	},
 }
 
 func Test(t *testing.T) {


### PR DESCRIPTION
I'm not sure if your fork is even intended to be extended further. However, when printing tables with color escape sequences, the normal tabwriter messes up the column width, because it counts the escape sequence as printable text.

This PR introduces a new flag `SmashEscape` which will treat all escaped text as zero-width. That way, color codes can be used in tables.