### PR TITLE
Add a public function IsEmpty()

### DIFF
--- a/tabwriter.go
+++ b/tabwriter.go
@@ -629,6 +629,11 @@ func (b *Writer) Write(buf []byte) (n int, err error) {
 	return
 }
 
+// IsEmpty returns true if the writer b holds no content.
+func (b *Writer) IsEmpty() bool {
+	return b.cell.size == 0 && len(b.lines) == 0
+}
+
 // NewWriter allocates and initializes a new tabwriter.Writer.
 // The parameters are the same as for the Init function.
 //


### PR DESCRIPTION
- add a public function IsEmpty() to know in advance whether w.Flush() will write content or not.
- it can ease the caller (e.g. kubectl) organize its table printing.

@liggitt Please take a look if it makes sense to you. I can add unit tests later.

The background is that even with https://github.com/kubernetes/kubernetes/pull/78774, `kubectl get all` ( or `kubectl get res1>,res2`) will output an empty line if the last resource(res2) has no elements. And it seems we have to know in advance whether `w.Flush()` will write content or not.

```
⇒  _output/local/bin/darwin/amd64/kubectl get svc,po                                                                                      local-up-cluster
NAME                 TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
service/kubernetes   ClusterIP   10.0.0.1     <none>        443/TCP   64m
<empty line here>
```